### PR TITLE
Replace internal-to-footer logic with footer wrapper

### DIFF
--- a/_templates/page.html.erb
+++ b/_templates/page.html.erb
@@ -67,7 +67,7 @@
       </div>
     </div>
     <div class="visible-xs-block row row-offcanvas row-offcanvas-left">
-      <%= render((distro_key == 'openshift-origin' ? "_templates/_footer_origin.html.erb" : "_templates/_footer_other.html.erb"), :images_path => images_path) %>
+      <%= render("_templates/_footer.html.erb", :distro_key => distro_key, :images_path => images_path) %>
     </div>
   </div>
   <script type="text/javascript">


### PR DESCRIPTION
@sg00dwin please merge this into your branch. It does literally the same thing as your code but does it through the main _footer.html.erb, which preserves the abstraction level that we want in the page template. After you pull this in I can merge your PR against openshift-docs.

Thanks!
